### PR TITLE
Fix formatting issue so you don't need to gsub

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ GlobalPhone is heavily inspired by Andreas Gal's [PhoneNumber.js](https://github
 
 ### Version History
 
+**1.0.2** (Unreleased)
+
+* Fix formatting issue so you don't need to gsub
+
 **1.0.1** (May 29, 2013)
 
 * GlobalPhone::Number#to_s returns the E.164 international string.

--- a/lib/global_phone/number.rb
+++ b/lib/global_phone/number.rb
@@ -8,7 +8,7 @@ module GlobalPhone
     VALID_ALPHA_CHARS  = /[a-zA-Z]/
     LEADING_PLUS_CHARS = /^\++/
     NON_DIALABLE_CHARS = /[^,#+\*\d]/
-    SPLIT_FIRST_GROUP  = /^(\d+)(.*)$/
+    SPLIT_FIRST_GROUP  = /^(\d+)\W*(.*)$/
 
     def self.normalize(string)
       string.to_s.

--- a/test/edge_test.rb
+++ b/test/edge_test.rb
@@ -15,7 +15,7 @@ module GlobalPhone
       # We don't include those formats in our database, so we fall
       # back to the closest match.
       number = context.parse("1520123456", "IE")
-      assert_equal "1520  123 456", number.national_format
+      assert_equal "1520 123 456", number.national_format
     end
   end
 end


### PR DESCRIPTION
eg. current behaviour

```
GlobalPhone.parse("1520123456", "IE").national_format
#=> "1520  123 456"
```

gsub workaround:

```
GlobalPhone.parse("1520123456", "IE").national_format.gsub(/\s+/, ' ')
#=> "1520 123 456"
```
