### PR TITLE
Add global_phone validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
+Gemfile.lock
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+script: "bundle exec rake"
+rvm:
+  #- 1.8.7
+  #- ree
+  - 1.9.2
+  - 1.9.3
+  - 2.0.0
+  #- jruby-18mode
+  - jruby-19mode
+  - jruby-head
+  #- rbx-18mode
+  - rbx-19mode
+  #- ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gemspec :name => :global_phone
+
+group :test do
+  gem 'rake'
+  gem 'json'
+  gem 'mocha'
+  gem 'supermodel'
+end

--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ GlobalPhone.normalize("(0) 20-7031-3000", :gb)
 # => "+442070313000"
 ```
 
+Validate global phone numbers in Rails 3.x and ActiveModel.
+
+```ruby
+class Person < ActiveRecord::Base
+  validates :home_phone, :global_phone => true
+end
+
+Person.new(home_phone: '+61 3 9876 0010').valid?
+# => true
+
+class User < ActiveRecord::Base
+  attribute :work_country_code
+
+  validates :work_phone, :global_phone => { :using => :work_country_code }
+end
+
+User.new(work_phone: '03 9876 0010').valid?
+# => true
+```
+
 ## Caveats
 
 GlobalPhone currently does not parse emergency numbers or SMS short code numbers.
@@ -145,6 +165,10 @@ If you've found a bug or have a question, please open an issue on the [issue tra
 GlobalPhone is heavily inspired by Andreas Gal's [PhoneNumber.js](https://github.com/andreasgal/PhoneNumber.js) library.
 
 ### Version History
+
+**1.0.2** (Unreleased)
+
+* Add GlobalPhone ActiveModel Validator
 
 **1.0.1** (May 29, 2013)
 

--- a/lib/global_phone/locale/phone_number_validator.en.yml
+++ b/lib/global_phone/locale/phone_number_validator.en.yml
@@ -1,0 +1,4 @@
+en:
+  errors:
+    messages:
+      invalid_phone_number: "is not a valid phone number in region - %{country_code} (Try using international format '+61 3 9876 0010')"

--- a/lib/global_phone/validator.rb
+++ b/lib/global_phone/validator.rb
@@ -1,0 +1,13 @@
+I18n.load_path << File.dirname(__FILE__) + '/locale/phone_number_validator.en.yml'
+
+class GlobalPhoneValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    args = [value]
+    if (using = options[:using]) && (country_code = record.send(using))
+      args << country_code
+    end
+    unless GlobalPhone.validate(*args)
+      record.errors.add attribute, :invalid_phone_number, country_code: country_code
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
 require 'test/unit'
+require 'mocha/setup'
+require 'supermodel'
 require 'global_phone'
+require_relative '../lib/global_phone/validator'
 require 'json'
 
 module GlobalPhone

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -1,0 +1,112 @@
+require File.expand_path('../test_helper', __FILE__)
+
+class User < SuperModel::Base
+  include ActiveModel::Validations::Callbacks
+end
+
+class GlobalPhoneValidatorTest < GlobalPhone::TestCase
+  COUNTRY_CODE               = 'AU'
+
+  INVALID_PHONE_NUMBER       = '(06) 9876 0010'
+  LOCAL_PHONE_NUMBER         = '9876 0010'
+  NATIONAL_PHONE_NUMBER      = '(03) 9876 0010'
+  INTERNATIONAL_PHONE_NUMBER = '+61 3 9876 0010'
+
+  ATTRIBUTE              = :work_mobile
+  COUNTRY_CODE_ATTRIBUTE = :work_country_code
+  WORK_MOBILE            = '0432 101 234'
+
+  DEFAULT_MESSAGE =
+    "is not a valid phone number in region -  (Try using international format '+61 3 9876 0010')"
+  DEFAULT_MESSAGE_WITH_COUNTRY_CODE =
+    "is not a valid phone number in region - #{COUNTRY_CODE} (Try using international format '+61 3 9876 0010')"
+
+  def setup
+    @validator = nil
+    GlobalPhone.db_path = fixture_path('record_data.json')
+  end
+
+  def validator
+    @validator ||= GlobalPhoneValidator.new({attributes: [ATTRIBUTE]}.merge(@validator_options))
+  end
+
+  def model
+    @model ||= User.new.tap { |u|
+      u.stubs(ATTRIBUTE).returns(WORK_MOBILE)
+      u.stubs(COUNTRY_CODE_ATTRIBUTE).returns(@work_country_code)
+    }
+  end
+
+  def using_country_code
+    @work_country_code = 'AU'
+    @validator_options = { using: COUNTRY_CODE_ATTRIBUTE }
+  end
+
+
+  def subject(work_country_code, validator_options, phone_number)
+    @work_country_code = work_country_code
+    @validator_options = validator_options
+    validator.validate_each(model, ATTRIBUTE, phone_number)
+  end
+
+
+  test "when using country_code and an invalid phone number" do
+    subject('AU', { using: COUNTRY_CODE_ATTRIBUTE }, INVALID_PHONE_NUMBER)
+    assert_equal model.errors, {ATTRIBUTE=>[DEFAULT_MESSAGE_WITH_COUNTRY_CODE]}
+  end
+
+  test "when using country_code and a local phone number" do
+    subject('AU', { using: COUNTRY_CODE_ATTRIBUTE }, LOCAL_PHONE_NUMBER)
+    assert_equal model.errors, {ATTRIBUTE=>[DEFAULT_MESSAGE_WITH_COUNTRY_CODE]}
+  end
+
+  test "when using country_code and a national phone number" do
+    subject('AU', { using: COUNTRY_CODE_ATTRIBUTE }, NATIONAL_PHONE_NUMBER)
+    assert_equal model.errors, {}
+  end
+
+  test "when using country_code and an international phone number" do
+    subject('AU', { using: COUNTRY_CODE_ATTRIBUTE }, INTERNATIONAL_PHONE_NUMBER)
+    assert_equal model.errors, {}
+  end
+
+  test "when not using country_code and an invalid phone number" do
+    subject(nil, { }, INVALID_PHONE_NUMBER)
+    assert_equal model.errors, {ATTRIBUTE=>[DEFAULT_MESSAGE]}
+  end
+
+  test "when not using country_code and a local phone number" do
+    subject(nil, { }, LOCAL_PHONE_NUMBER)
+    assert_equal model.errors, {ATTRIBUTE=>[DEFAULT_MESSAGE]}
+  end
+
+  test "when not using country_code and a national phone number" do
+    subject(nil, { }, NATIONAL_PHONE_NUMBER)
+    assert_equal model.errors, {ATTRIBUTE=>[DEFAULT_MESSAGE]}
+  end
+
+  test "when not using country_code and an international phone number" do
+    subject(nil, { }, INTERNATIONAL_PHONE_NUMBER)
+    assert_equal model.errors, {}
+  end
+
+  test "README example 1" do
+    class Person < SuperModel::Base
+      validates :home_phone, :global_phone => true
+    end
+
+    assert_equal true, Person.new(home_phone: INTERNATIONAL_PHONE_NUMBER).valid?
+  end
+
+  test "README example 2" do
+    class User < SuperModel::Base
+      validates :work_phone, :global_phone => { :using => :work_country_code }
+
+      def work_country_code
+        'AU'
+      end
+    end
+
+    assert_equal true, User.new(work_phone: NATIONAL_PHONE_NUMBER).valid?
+  end
+end


### PR DESCRIPTION
Validate global phone numbers in Rails 3.x and ActiveModel.

``` ruby
class Person < ActiveRecord::Base
  validates :home_phone, :global_phone => true
end

Person.new(home_phone: '+61 3 9876 0010').valid?
# => true

class User < ActiveRecord::Base
  validates :work_phone, :global_phone => { :using => :work_country_code }

  def work_country_code
    'AU'
  end
end

User.new(work_phone: '03 9876 0010').valid?
# => true
```
