### PR TITLE
Check number validity for all matching territories

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Sam Stephenson
+Copyright (c) 2013 Sam Stephenson
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -146,10 +146,6 @@ GlobalPhone is heavily inspired by Andreas Gal's [PhoneNumber.js](https://github
 
 ### Version History
 
-**1.0.2** (January 6, 2014)
-
-* If a number matches multiple territories, attempt to select one for which the number is valid.
-
 **1.0.1** (May 29, 2013)
 
 * GlobalPhone::Number#to_s returns the E.164 international string.
@@ -162,6 +158,6 @@ GlobalPhone is heavily inspired by Andreas Gal's [PhoneNumber.js](https://github
 
 ### License
 
-Copyright &copy; 2014 Sam Stephenson
+Copyright &copy; 2013 Sam Stephenson
 
 Released under the MIT license. See [`LICENSE`](LICENSE) for details.

--- a/lib/global_phone.rb
+++ b/lib/global_phone.rb
@@ -1,7 +1,7 @@
 require 'global_phone/context'
 
 module GlobalPhone
-  VERSION = '1.0.2'
+  VERSION = '1.0.1'
 
   class Error < ::StandardError; end
   class NoDatabaseError < Error; end


### PR DESCRIPTION
This fixes #17, though I'm not sure that it is the right fix. With this PR, rather than returning the first matching territory, we attempt to find a matching territory for which the number is valid.

/cc @josh @sstephenson
