### PR TITLE
Error handling for 404

### DIFF
--- a/bin/global_phone_dbgen
+++ b/bin/global_phone_dbgen
@@ -52,8 +52,12 @@ while arg = ARGV.shift
   end
 end
 
-generator = GlobalPhone::DatabaseGenerator.load(open(path).read)
-result = generator.send(method)
+begin
+  generator = GlobalPhone::DatabaseGenerator.load(open(path).read)
+  result = generator.send(method)
+rescue => e
+  puts "Could not retrieve remote XML: #{e}"
+end
 
 if compact
   puts JSON.generate(result)


### PR DESCRIPTION
When trying to use this gem, I get a 404 error. I don't know why, the remote XML file loads fine from a browser, but this will at least allow it to spit out an error.