### PR TITLE
Fixes issue with partial matches.

### DIFF
--- a/lib/global_phone/format.rb
+++ b/lib/global_phone/format.rb
@@ -10,7 +10,10 @@ module GlobalPhone
 
     def match(national_string, match_leading_digits = true)
       return false if match_leading_digits && leading_digits && national_string !~ leading_digits
-      national_string =~ pattern
+      if match = pattern.match(national_string)
+        return match[0].length == national_string.length
+      end
+      false
     end
 
     def format_replacement_string(type)

--- a/lib/global_phone/number.rb
+++ b/lib/global_phone/number.rb
@@ -54,7 +54,11 @@ module GlobalPhone
     end
 
     def valid?
-      !!(format && national_string =~ national_pattern)
+      return unless !!format
+      if match = national_pattern.match(national_string)
+        return match[0] == national_string
+      end
+      false
     end
 
     def inspect

--- a/test/number_test.rb
+++ b/test/number_test.rb
@@ -56,5 +56,26 @@ module GlobalPhone
       number = context.parse("(312) 555-1212")
       assert_equal "+1 312-555-1212", number.international_format
     end
+
+    test "partial matches do not validate" do
+      # Guatemala has eight digit phone numbers, but the number 5555
+      # 1234 123 still got through the matcher.
+      # 
+      # The regex is /^[2-7]\d{7}|1[89]\d{9}$/, but with =~ matching a
+      # partial match is still possible.
+      # 
+      # I think this might actually be a broken regex, but changing
+      # the code seems better than mucking about with all the regex's
+      # from google.
+      number = context.parse("5555 1234 123", :gt)
+      assert !number || !number.valid?
+    end
+
+    test "national format with or in regex still works with correct number" do
+      number = context.parse("5555 2134", :gt)
+      assert number.valid?
+    end
+
+
   end
 end


### PR DESCRIPTION
Hi. I don't know if this is a great way to fix this problem, but I thought I'd take a swing at it and see what you thought.

The problem: an invalid number is counted as valid because anchors (^, $) are ignored on a regular expression. I think this happens because the regex also has an OR / pipe operator ( | ).

Example: 
Guatemala has eight digit phone numbers, but the number 5555 1234 123 still got through the matcher.

The regex:
 /^[2-7]\d{7}|1[89]\d{9}$/

As you can see, the number does not match either of the sides of the expression delimited by the pipe. Probably, it should all be wrapped in parentheses or something. But, I don't want to change all the libphonenumber regex's to solve the problem, because then I can't update from their database very easily.

The solution is completely invalid if there are times that a partial match in the sections I have changed will happen. This was somewhat unclear to me, but I believe that at these points, we are matching the entire number.

Thanks.