### PR TITLE
Strip leading country code without leading plus

### DIFF
--- a/lib/global_phone/territory.rb
+++ b/lib/global_phone/territory.rb
@@ -31,20 +31,22 @@ module GlobalPhone
     end
 
     protected
-      def strip_national_prefix(string)
+      def strip_prefixes(string)
         if national_prefix_for_parsing
           transform_rule = national_prefix_transform_rule || ""
           transform_rule = transform_rule.gsub("$", "\\")
           string_without_prefix = string.sub(national_prefix_for_parsing, transform_rule)
         elsif starts_with_national_prefix?(string)
           string_without_prefix = string[national_prefix.length..-1]
+        elsif starts_with_country_code?(string)
+          string_without_prefix = string[country_code.length..-1]
         end
 
         possible?(string_without_prefix) ? string_without_prefix : string
       end
 
       def normalize(string)
-        strip_national_prefix(Number.normalize(string))
+        strip_prefixes(Number.normalize(string))
       end
 
       def possible?(string)
@@ -53,6 +55,10 @@ module GlobalPhone
 
       def starts_with_national_prefix?(string)
         national_prefix && string.index(national_prefix) == 0
+      end
+
+      def starts_with_country_code?(string)
+        country_code && string.index(country_code) == 0
       end
   end
 end

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -27,6 +27,11 @@ module GlobalPhone
         :country_code => "1", :national_string => "3125551212"
     end
 
+    test "parsing international number with country code prefix but no plus" do
+      assert_parses "(504) 2221-6592", :with_territory => :hn,
+        :country_code => "504", :national_string => "22216592"
+    end
+
     test "changing the default territory" do
       assert_does_not_parse "(0) 20-7031-3000"
 


### PR DESCRIPTION
Given a country like Honduras with a country code of 504, if a number is formatted like (504) 2221-6592, it will not parse as it's an international string, however it does not start with a plus or the international prefix.

Now the territory will check if it starts with the country code before parsing and strip the country code when it is prefixed.
