### PR TITLE
Update URL for retrieving the libphonenumber metadata

### DIFF
--- a/bin/global_phone_dbgen
+++ b/bin/global_phone_dbgen
@@ -2,7 +2,7 @@
 require 'global_phone/database_generator'
 require 'open-uri'
 
-REMOTE_URL = "http://libphonenumber.googlecode.com/svn/trunk/resources/PhoneNumberMetadata.xml"
+REMOTE_URL = "https://raw.githubusercontent.com/googlei18n/libphonenumber/master/resources/PhoneNumberMetadata.xml"
 
 def usage
   warn "Usage: #$0 [--compact] [--test] [<filename> | <url>]"


### PR DESCRIPTION
Attempted to use global phone and was unable to generate the json file. Updated the metadata URL to point to github and hey presto, it works!