### PR TITLE
Fix numbers which start with country codes.

### DIFF
--- a/lib/global_phone/territory.rb
+++ b/lib/global_phone/territory.rb
@@ -38,7 +38,7 @@ module GlobalPhone
           string_without_prefix = string.sub(national_prefix_for_parsing, transform_rule)
         elsif starts_with_national_prefix?(string)
           string_without_prefix = string[national_prefix.length..-1]
-        elsif starts_with_country_code?(string)
+        elsif !possible?(string) && starts_with_country_code?(string)
           string_without_prefix = string[country_code.length..-1]
         end
 

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -22,6 +22,11 @@ module GlobalPhone
         :country_code => "44", :national_string => "2070313000"
     end
 
+    test "parsing national number for given territory with leading country code" do
+      assert_parses "3914172422", :with_territory => :it,
+        :country_code => "39", :national_string => "3914172422"
+    end
+
     test "parsing international number with prefix" do
       assert_parses "00 1 3125551212", :with_territory => :gb,
         :country_code => "1", :national_string => "3125551212"


### PR DESCRIPTION
This fixes a regression in #35 where numbers that start with the country code have those leading numbers stripped, rendering the resulting number invalid.

Good examples of this are the mobile phone numbers of H3G (Three Italy) whose numbers (starting with 390_, 391, 392, 393, 397_) match the country code of Italy (39).
