### PR TITLE
Allow E161 substitution to be skipped

### DIFF
--- a/lib/global_phone/context.rb
+++ b/lib/global_phone/context.rb
@@ -19,8 +19,8 @@ module GlobalPhone
       @default_territory_name = territory_name.to_s.intern
     end
 
-    def parse(string, territory_name = default_territory_name)
-      db.parse(string, territory_name)
+    def parse(string, territory_name = default_territory_name, skip_e161=false)
+      db.parse(string, territory_name, skip_e161)
     end
 
     def normalize(string, territory_name = default_territory_name)

--- a/lib/global_phone/number.rb
+++ b/lib/global_phone/number.rb
@@ -10,11 +10,11 @@ module GlobalPhone
     NON_DIALABLE_CHARS = /[^,#+\*\d]/
     SPLIT_FIRST_GROUP  = /^(\d+)(.*)$/
 
-    def self.normalize(string)
-      string.to_s.
-        gsub(VALID_ALPHA_CHARS) { |c| E161_MAPPING[c.downcase] }.
-        gsub(LEADING_PLUS_CHARS, "+").
-        gsub(NON_DIALABLE_CHARS, "")
+    def self.normalize(string, skip_e161=false)
+      str = string.to_s
+
+      str = str.gsub(VALID_ALPHA_CHARS) { |c| E161_MAPPING[c.downcase] } unless skip_e161
+      str.gsub(LEADING_PLUS_CHARS, '+').gsub(NON_DIALABLE_CHARS, '')
     end
 
     attr_reader :territory, :national_string

--- a/lib/global_phone/parsing.rb
+++ b/lib/global_phone/parsing.rb
@@ -3,8 +3,8 @@ require 'global_phone/utils'
 
 module GlobalPhone
   module Parsing
-    def parse(string, territory_name)
-      string = Number.normalize(string)
+    def parse(string, territory_name, skip_e161=false)
+      string = Number.normalize(string, skip_e161)
       territory = self.territory(territory_name)
       raise ArgumentError, "unknown territory `#{territory_name}'" unless territory
 


### PR DESCRIPTION
I'll add some tests to this later, but with this PR `GlobalPhone.parse("aaaaaaa", :US, true) == nil` as one would expect :)