### PR TITLE
Fix: regex error with leading_digits

### DIFF
--- a/lib/global_phone/format.rb
+++ b/lib/global_phone/format.rb
@@ -4,7 +4,7 @@ module GlobalPhone
   class Format < Record
     field 0, :pattern do |p| /^#{p}$/ end
     field 1, :national_format_rule
-    field 2, :leading_digits do |d| /^#{d}/ end
+    field 2, :leading_digits do |d| /^(#{d})/ end
     field 3, :national_prefix_formatting_rule
     field 4, :international_format_rule, :fallback => :national_format_rule
 

--- a/lib/global_phone/number.rb
+++ b/lib/global_phone/number.rb
@@ -81,7 +81,8 @@ module GlobalPhone
 
         prefix = prefix.gsub("$NP", national_prefix)
         prefix = prefix.gsub("$FG", match[1])
-        result = "#{prefix} #{match[2]}"
+
+        result = "#{prefix}#{match[2]}"
       end
 
       def national_prefix_formatting_rule

--- a/test/edge_test.rb
+++ b/test/edge_test.rb
@@ -15,7 +15,7 @@ module GlobalPhone
       # We don't include those formats in our database, so we fall
       # back to the closest match.
       number = context.parse("1520123456", "IE")
-      assert_equal "1520  123 456", number.national_format
+      assert_equal "1520 123 456", number.national_format
     end
   end
 end

--- a/test/format_test.rb
+++ b/test/format_test.rb
@@ -1,0 +1,16 @@
+require File.expand_path('../test_helper', __FILE__)
+
+module GlobalPhone
+  class FormatTest < TestCase
+    test 'non-matching leading digits' do
+      assert_false format.match('1582380560', true)
+    end
+
+    def format
+      # This is a GB format taken from the seed data.
+      Format.new(["(\\d{2})(\\d{4})(\\d{4})",
+                  "$1 $2 $3",
+                  "2|5[56]|7(?:0|6[013-9])2|5[56]|7(?:0|6(?:[013-9]|2[0-35-9]))"])
+    end
+  end
+end


### PR DESCRIPTION
When parsing `leading_digits` for number formats, `^` is being
concatenated to the format, but many leading_digit formats contain the
`|` operator. For this reason, `Format#match` returns some false
positives. I.E., `/^2|5[56]/` matches the phone number 1582380560.

This commit wraps the leading_digits expression in ()s before applying
the ^ so all of the formats must match the start of the line.