### PR TITLE
Adds logger / Removes raise exception when unknown territory

### DIFF
--- a/lib/global_phone/logger.rb
+++ b/lib/global_phone/logger.rb
@@ -1,0 +1,13 @@
+require 'logger'
+
+module GlobalPhone
+  class << self
+    attr_writer :logger
+
+    def logger
+      @logger ||= Logger.new($stdout).tap do |log|
+        log.progname = self.name
+      end
+    end
+  end
+end

--- a/lib/global_phone/parsing.rb
+++ b/lib/global_phone/parsing.rb
@@ -1,12 +1,14 @@
 require 'global_phone/number'
 require 'global_phone/utils'
+require 'global_phone/logger'
 
 module GlobalPhone
   module Parsing
     def parse(string, territory_name)
       string = Number.normalize(string)
       territory = self.territory(territory_name)
-      raise ArgumentError, "unknown territory `#{territory_name}'" unless territory
+
+      GlobalPhone.logger.warn "unknown territory `#{territory_name}'" unless territory
 
       if starts_with_plus?(string)
         parse_international_string(string)

--- a/test/parsing_test.rb
+++ b/test/parsing_test.rb
@@ -1,0 +1,23 @@
+require File.expand_path('../test_helper', __FILE__)
+require 'pry'
+require 'stringio'
+
+module GlobalPhone
+  class ParsingTest < TestCase
+    test "valid territory" do
+      number = context.parse("+351 91 335 00 00", "PT")
+      assert_not_nil number
+      assert_kind_of Territory, number.territory
+    end
+
+    test "unknown territory" do
+      stdout = StringIO.new
+      $stdout = stdout
+      number = context.parse("+93 1289312", "PN")
+      $stdout = STDOUT
+
+      assert_nil number
+      assert_match 'unknown territory', stdout.string
+    end
+  end
+end


### PR DESCRIPTION
So there are some countries that aren't on Database, but they exist: https://github.com/googlei18n/libphonenumber/issues/76

IMHO raising an exception it's not the best solution when we have an invalid territory. 

So my suggestion is to log it as a warning, but return nil.

`GlobalPhone.parse("+93 1289312", "PN")`
> ArgumentError: unknown territory `PN'


VS

`GlobalPhone.parse("+93 1289312", "PN")`
> nil


